### PR TITLE
Adding 'end' method to stream

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb-base",
   "rules": {
+    "strict": "off",
     "arrow-body-style": ["warn", "always"],
     "space-in-parens": [ "error", "always" ],
     "array-bracket-spacing": [ "warn", "always" ],

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 /**
  * Bunyan Log Stream compatible with SumoLogic
@@ -78,6 +78,7 @@ module.exports = function SumoLogger( opts ) {
             return cb( null );
         }
         onEnd = cb;
+        return false;
     };
 
     let numBeingSent = 0;

--- a/index.js
+++ b/index.js
@@ -69,15 +69,15 @@ module.exports = function SumoLogger( opts ) {
 
         unsynced.push( safeToString( record ) );
     };
-    
+
     /**
      * `end` function will run the callback after the sync queue is empty
      */
     this.end = ( cb ) => {
         if ( unsynced.length === 0 ) {
-            return cb();
+            return cb( null );
         }
-        onEnd = cb;        
+        onEnd = cb;
     };
 
     let numBeingSent = 0;
@@ -110,15 +110,15 @@ module.exports = function SumoLogger( opts ) {
             if ( !failed ) {
                 unsynced.splice( 0, numBeingSent );
             }
-            
+
             numBeingSent = 0;
-            
+
             if ( onEnd ) {
                 // if we are failing to log we are not going to wait
                 if ( failed ) {
-                    onEnd(error);
+                    onEnd( error );
                 } else if ( unsynced.length === 0 ) {
-                    onEnd(null);
+                    onEnd( null );
                 }
                 onEnd = false;
             }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = function SumoLogger( opts ) {
     const collectorEndpoint = endpoint + opts.collector;
     const syncInterval = opts.syncInterval || 1000;
     const maxLines = opts.maxLines || 100;
+    let onEnd = false;
 
     let rewriteLevels = true;
     if ( opts.rewriteLevels !== undefined ) {
@@ -68,7 +69,16 @@ module.exports = function SumoLogger( opts ) {
 
         unsynced.push( safeToString( record ) );
     };
-
+    
+    /**
+     * `end` function will run the callback after the sync queue is empty
+     */
+    this.end = ( cb ) => {
+        if ( unsynced.length === 0 ) {
+            return cb();
+        }
+        onEnd = cb;        
+    };
 
     let numBeingSent = 0;
 
@@ -100,7 +110,18 @@ module.exports = function SumoLogger( opts ) {
             if ( !failed ) {
                 unsynced.splice( 0, numBeingSent );
             }
+            
             numBeingSent = 0;
+            
+            if ( onEnd ) {
+                // if we are failing to log we are not going to wait
+                if ( failed ) {
+                    onEnd(error);
+                } else if ( unsynced.length === 0 ) {
+                    onEnd(null);
+                }
+                onEnd = false;
+            }
         } );
     }
     setInterval( syncLogsToSumo, syncInterval );


### PR DESCRIPTION
This is required in order to safely exit an application only after all logs have been transmitted.

There is one issue here - If there are a lot of writes then the `onEnd` callback might wait a long time - potentially forever. Would we want to set a timeout on that or even block writes after 'end' has been called ? (The latter being default node stream behavior)

